### PR TITLE
Cross-compile powerpc binary

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,5 @@
-FROM ppc64le/golang:1.9-alpine as builder
+# builder image
+FROM golang:1.9-alpine as builder
 
 RUN apk --no-cache add git
 RUN go get github.com/golang/dep/cmd/dep
@@ -6,15 +7,13 @@ WORKDIR /go/src/github.com/linki/chaoskube
 COPY . .
 RUN dep ensure
 RUN go test -v ./...
-RUN go build -o /bin/chaoskube -v \
+RUN GOARCH=ppc64le go build -o /bin/chaoskube -v \
   -ldflags "-X main.version=$(git describe --tags --always --dirty) -w -s"
 
 # final image
 FROM ppc64le/alpine:3.6
 MAINTAINER Linki <linki+docker.com@posteo.de>
 
-RUN apk --no-cache add dumb-init && addgroup -S chaoskube && adduser -S -g chaoskube chaoskube
 COPY --from=builder /bin/chaoskube /bin/chaoskube
 
-USER chaoskube
-ENTRYPOINT ["dumb-init", "--", "/bin/chaoskube"]
+ENTRYPOINT ["/bin/chaoskube"]


### PR DESCRIPTION
@hchenxa An update to your PR over at https://github.com/linki/chaoskube/pull/60.

Would it be possible to cross-compile on x86 for power so that we can build the image on `quay.io`? To make this build an image on my machine I had to remove `dumb-init` and the `adduser` calls in the final image. Maybe you have an idea on how to keep them.

Unfortunately, I don't have a machine to test that this actually works.

 see https://github.com/linki/chaoskube/pull/60#issuecomment-382406255